### PR TITLE
docs: add MSVC 2017 (+) note to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   
 ## Running the Pretrained Model Interactively 🎮  
 🐍 Python 3.10 is recommended. Other versions may work but have not been tested.   
-You also need to install ffmpeg and have it available in the command line.
+You also need to install ffmpeg and have it available in the command line, as well as having MSVC 2017 (or newer) installed.
 
 1. Copy your legally obtained Pokemon Red ROM into the base directory. You can find this using google, it should be 1MB. Rename it to `PokemonRed.gb` if it is not already. The sha1 sum should be `ea9bcae617fdf159b045185467ae58b2e4a48b9a`, which you can verify by running `shasum PokemonRed.gb`. 
 2. Move into the `baselines/` directory:  


### PR DESCRIPTION
```
 fatal error C1189: #error:  pybind11 2.10+ requires MSVC 2017 or newer
```

MSVC 2017+ must be installed for `pip install -r requirements.txt` to work