### PR TITLE
fixed prog_color visualization bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ _autoplay.mp4
 session_*
 .env
 PokemonRed.gb.state
+wandb
+*.npz
+*.mp4


### PR DESCRIPTION
I couldn't get this file to run with the current version of the repository. I've made several changes to fix bugs that I encountered. Here's a rundown of the changes:

- The background map wasn't being combined with the sprite overlay. This has been fixed.
- I've added coordinates to location 193 (Route 22 check gate) to avoid a type error when entering that area. Side note: This room doesn't line up with the coordinate grid very well. If someone with photoshop skills could move it to the right a few pixels, that would be awesome!
- Added the session name to the base_coords.npz and video file names
- Altered paths to allow this to run from the root directory. You will need to create 2 folders named 'coords' and 'videos' inside the visualization folder
- Replaced Pool.starmap() with a for loop. Pool.starmap() was giving me a broken pipe error while trying to create the videos. This is a temp fix until I can find a better solution.
- I changed the codec to h264 to get the video to play on windows using vlc. However, h264 doesn't support rgba, so the sprite colors are a little wonky for now until I have time to mess with the color scheme.
- Changed run_steps to 20480 to match the default episode length

The script still isn't perfect, but you should be able to run it now with minimal hassle.