### PR TITLE
set model params consistently on reload

### DIFF
--- a/baselines/run_baseline_parallel_fast.py
+++ b/baselines/run_baseline_parallel_fast.py
@@ -9,6 +9,7 @@ from stable_baselines3.common.utils import set_random_seed
 from stable_baselines3.common.callbacks import CheckpointCallback, CallbackList
 from tensorboard_callback import TensorboardCallback
 
+
 def make_env(rank, env_conf, seed=0):
     """
     Utility function for multiprocessed env.
@@ -17,70 +18,105 @@ def make_env(rank, env_conf, seed=0):
     :param seed: (int) the initial seed for RNG
     :param rank: (int) index of the subprocess
     """
+
     def _init():
         env = RedGymEnv(env_conf)
         env.reset(seed=(seed + rank))
         return env
+
     set_random_seed(seed)
     return _init
 
-if __name__ == '__main__':
 
+if __name__ == "__main__":
     use_wandb_logging = False
     ep_length = 2048 * 10
     sess_id = str(uuid.uuid4())[:8]
-    sess_path = Path(f'session_{sess_id}')
+    sess_path = Path(f"session_{sess_id}")
 
     env_config = {
-                'headless': True, 'save_final_state': True, 'early_stop': False,
-                'action_freq': 24, 'init_state': '../has_pokedex_nballs.state', 'max_steps': ep_length, 
-                'print_rewards': True, 'save_video': False, 'fast_video': True, 'session_path': sess_path,
-                'gb_path': '../PokemonRed.gb', 'debug': False, 'sim_frame_dist': 2_000_000.0, 
-                'use_screen_explore': True, 'reward_scale': 4, 'extra_buttons': False,
-                'explore_weight': 3 # 2.5
-            }
-    
+        "headless": True,
+        "save_final_state": True,
+        "early_stop": False,
+        "action_freq": 24,
+        "init_state": "../has_pokedex_nballs.state",
+        "max_steps": ep_length,
+        "print_rewards": True,
+        "save_video": False,
+        "fast_video": True,
+        "session_path": sess_path,
+        "gb_path": "../PokemonRed.gb",
+        "debug": False,
+        "sim_frame_dist": 2_000_000.0,
+        "use_screen_explore": True,
+        "reward_scale": 4,
+        "extra_buttons": False,
+        "explore_weight": 3,  # 2.5
+    }
+
     print(env_config)
-    
+
     num_cpu = 16  # Also sets the number of episodes per training iteration
     env = SubprocVecEnv([make_env(i, env_config) for i in range(num_cpu)])
-    
-    checkpoint_callback = CheckpointCallback(save_freq=ep_length, save_path=sess_path,
-                                     name_prefix='poke')
-    
+
+    checkpoint_callback = CheckpointCallback(
+        save_freq=ep_length, save_path=sess_path, name_prefix="poke"
+    )
+
     callbacks = [checkpoint_callback, TensorboardCallback()]
 
     if use_wandb_logging:
         import wandb
         from wandb.integration.sb3 import WandbCallback
+
         run = wandb.init(
             project="pokemon-train",
             id=sess_id,
             config=env_config,
-            sync_tensorboard=True,  
-            monitor_gym=True,  
+            sync_tensorboard=True,
+            monitor_gym=True,
             save_code=True,
         )
         callbacks.append(WandbCallback())
 
-    #env_checker.check_env(env)
+    # env_checker.check_env(env)
     learn_steps = 40
+    n_steps = ep_length // 8
+    batch_size = 128
+    n_epochs = 3
+    gamma = 0.998
+    verbose = 1
+
     # put a checkpoint here you want to start from
-    file_name = 'session_e41c9eff/poke_38207488_steps' 
-    
-    if exists(file_name + '.zip'):
-        print('\nloading checkpoint')
+    file_name = "session_e41c9eff/poke_38207488_steps"
+
+    if exists(file_name + ".zip"):
+        print("\nloading checkpoint")
         model = PPO.load(file_name, env=env)
-        model.n_steps = ep_length
+        model.n_steps = n_steps
+        model.batch_size = batch_size
+        model.n_epochs = n_epochs
+        model.gamma = gamma
         model.n_envs = num_cpu
-        model.rollout_buffer.buffer_size = ep_length
-        model.rollout_buffer.n_envs = num_cpu
-        model.rollout_buffer.reset()
+        model.verbose = verbose
+        model.tensorboard_log = sess_path
     else:
-        model = PPO('CnnPolicy', env, verbose=1, n_steps=ep_length // 8, batch_size=128, n_epochs=3, gamma=0.998, tensorboard_log=sess_path)
-    
+        model = PPO(
+            "CnnPolicy",
+            env,
+            n_steps=n_steps,
+            batch_size=batch_size,
+            n_epochs=n_epochs,
+            gamma=gamma,
+            verbose=verbose,
+            tensorboard_log=sess_path,
+        )
+
     for i in range(learn_steps):
-        model.learn(total_timesteps=(ep_length)*num_cpu*1000, callback=CallbackList(callbacks))
+        model.learn(
+            total_timesteps=(ep_length) * num_cpu * 1000,
+            callback=CallbackList(callbacks),
+        )
 
     if use_wandb_logging:
         run.finish()


### PR DESCRIPTION
This PR resolves [Issue 148](https://github.com/PWhiddy/PokemonRedExperiments/issues/148), and ensures that parameters are explicitly set to the same values they would be if a new model had been created.

Apologies for the polluted diff - didn't realize that black had done its magic. The relevant lines are 84-111 in the updated file. Let me know if you'd prefer to leave it unformatted, and I can resubmit with only the relevant lines changed.