### PR TITLE
Fix agent disabling in v2 by using emulator tick instead of PASS action

### DIFF
--- a/v2/run_pretrained_interactive.py
+++ b/v2/run_pretrained_interactive.py
@@ -72,7 +72,6 @@ if __name__ == '__main__':
     #keyboard.on_press_key("M", toggle_agent)
     obs, info = env.reset()
     while True:
-        action = 7 # pass action
         try:
             with open("agent_enabled.txt", "r") as f:
                 agent_enabled = f.readlines()[0].startswith("yes")
@@ -80,7 +79,9 @@ if __name__ == '__main__':
             agent_enabled = False
         if agent_enabled:
             action, _states = model.predict(obs, deterministic=False)
-        obs, rewards, terminated, truncated, info = env.step(action)
+            obs, rewards, terminated, truncated, info = env.step(action)
+        else:
+            env.pyboy.tick(1, True)
         env.render()
         if truncated:
             break

--- a/v2/run_pretrained_interactive.py
+++ b/v2/run_pretrained_interactive.py
@@ -82,6 +82,8 @@ if __name__ == '__main__':
             obs, rewards, terminated, truncated, info = env.step(action)
         else:
             env.pyboy.tick(1, True)
+            obs = env._get_obs()
+            truncated = env.step_count >= env.max_steps - 1
         env.render()
         if truncated:
             break


### PR DESCRIPTION
## Fix for issue #212 

Allows agent disabling in v2 without retraining